### PR TITLE
Validator Docstring improvements

### DIFF
--- a/yamlator/__init__.py
+++ b/yamlator/__init__.py
@@ -1,4 +1,9 @@
-"""Yamlator top level package"""
+"""Shortcuts for accessing common Yamlator functions"""
 
 from yamlator.validators.core import validate_yaml
 from yamlator.cmd import validate_yaml_data_from_file
+
+__all__ = [
+    'validate_yaml',
+    'validate_yaml_data_from_file'
+]

--- a/yamlator/validators/__init__.py
+++ b/yamlator/validators/__init__.py
@@ -1,11 +1,24 @@
-"""Yamlator validators package"""
+"""Shortcuts for accessing the Validators"""
 
-from .any_type_validator import AnyTypeValidator
-from .builtin_type_validator import BuiltInTypeValidator
-from .enum_type_validator import EnumTypeValidator
-from .list_validator import ListValidator
-from .map_validator import MapValidator
-from .optional_validator import OptionalValidator
-from .regex_validator import RegexValidator
-from .required_validator import RequiredValidator
-from .ruleset_validator import RulesetValidator
+from yamlator.validators.any_type_validator import AnyTypeValidator
+from yamlator.validators.builtin_type_validator import BuiltInTypeValidator
+from yamlator.validators.enum_type_validator import EnumTypeValidator
+from yamlator.validators.list_validator import ListValidator
+from yamlator.validators.map_validator import MapValidator
+from yamlator.validators.optional_validator import OptionalValidator
+from yamlator.validators.regex_validator import RegexValidator
+from yamlator.validators.required_validator import RequiredValidator
+from yamlator.validators.ruleset_validator import RulesetValidator
+
+
+__all__ = [
+    'AnyTypeValidator',
+    'BuiltInTypeValidator',
+    'EnumTypeValidator',
+    'ListValidator',
+    'MapValidator',
+    'OptionalValidator',
+    'RegexValidator',
+    'RequiredValidator',
+    'RulesetValidator'
+]

--- a/yamlator/validators/any_type_validator.py
+++ b/yamlator/validators/any_type_validator.py
@@ -1,4 +1,4 @@
-"""Validator for the any data type"""
+"""Validator for handling the any data type"""
 
 
 from yamlator.types import Data

--- a/yamlator/validators/any_type_validator.py
+++ b/yamlator/validators/any_type_validator.py
@@ -1,4 +1,4 @@
-"""Validator for the any time data type"""
+"""Validator for the any data type"""
 
 
 from yamlator.types import Data
@@ -8,20 +8,21 @@ from yamlator.validators.base_validator import Validator
 
 
 class AnyTypeValidator(Validator):
-    """Validator to handle the `any` type. This type ignores all type checks"""
+    """Validator to handle the `any` type. This type ignores all type checks
+    against the data"""
 
     def validate(self, key: str, data: Data, parent: str, rtype: RuleType,
                  is_required: bool = False) -> None:
         """Validate any rules that have the data marked as the `any` type
 
         Args:
-            key              (str): The key to the data
-            data            (Data): The data to validate
-            parent           (str): The parent key of the data
-            rtype       (RuleType): The type assigned to the rule
-            is_required     (bool): Is the rule required
+            key (str): The key to the data
+            data (Data): The data to validate
+            parent (str): The parent key of the data
+            rtype (RuleType): The type assigned to the rule that will be
+                applied to the data
+            is_required (bool, optional): Indicates if the rule is required
         """
-
         is_any_type = (rtype.schema_type == SchemaTypes.ANY)
         if is_any_type:
             return

--- a/yamlator/validators/base_validator.py
+++ b/yamlator/validators/base_validator.py
@@ -1,4 +1,4 @@
-"""Base validator"""
+"""Base Yamlator validator"""
 
 from __future__ import annotations
 from collections import deque
@@ -9,7 +9,7 @@ from yamlator.violations import TypeViolation
 
 
 class Validator:
-    """Base class for validating a rule against the data"""
+    """Base Validator handler"""
 
     _next_validator = None
 
@@ -18,7 +18,7 @@ class Validator:
 
         Args:
             violations (deque): Contains violations that have been detected
-            whilst processing the data
+                whilst processing the data
         """
         self._violations = violations
 
@@ -29,7 +29,7 @@ class Validator:
             validator (Validator): The next validator in the chain
 
         Returns:
-            The object that was provided in the `validator` parameter
+            Validator: The object that was provided in the `validator` parameter
         """
         self._next_validator = validator
         return validator
@@ -39,11 +39,12 @@ class Validator:
         """Validate the data against the next validator in the chain
 
         Args:
-            key              (str): The key to the data
-            data            (Data): The data to validate
-            parent           (str): The parent key of the data
-            rtype       (RuleType): The type assigned to the rule
-            is_required     (bool): Is the rule required
+            key (str): The key to the data
+            data (Data): The data to validate
+            parent (str): The parent key of the data
+            rtype (RuleType): The type assigned to the rule that will be
+                applied to the data
+            is_required (bool, optional): Indicates if the rule is required
         """
 
         if self._next_validator is not None:

--- a/yamlator/validators/builtin_type_validator.py
+++ b/yamlator/validators/builtin_type_validator.py
@@ -1,4 +1,4 @@
-"""Built in type validator"""
+"""Validator for handling the builtin types"""
 
 
 from collections import deque
@@ -13,14 +13,14 @@ _SchemaTypeDecoder = namedtuple('SchemaTypeDecoder', ['type', 'friendly_name'])
 
 
 class BuiltInTypeValidator(Validator):
-    """Validator to handle the build in types. e.g `int`, `list` & `str`"""
+    """Validator to handle the builtin types. e.g `int`, `list` & `str`"""
 
     def __init__(self, violations: deque) -> None:
         """BuiltInTypeValidator init
 
         Args:
             violations (deque): Contains violations that have been detected
-            whilst processing the data
+                whilst processing the data
         """
         super().__init__(violations)
         self._built_in_lookups = {
@@ -39,11 +39,12 @@ class BuiltInTypeValidator(Validator):
         to the list of violations
 
         Args:
-            key              (str): The key to the data
-            data            (Data): The data to validate
-            parent           (str): The parent key of the data
-            rtype       (RuleType): The type assigned to the rule
-            is_required     (bool): Is the rule required
+            key (str): The key to the data
+            data (Data): The data to validate
+            parent (str): The parent key of the data
+            rtype (RuleType): The type assigned to the rule that will be
+                applied to the data
+            is_required (bool, optional): Indicates if the rule is required
         """
         buildin_type = self._built_in_lookups.get(rtype.schema_type)
         is_not_build_in_type = (buildin_type is None)

--- a/yamlator/validators/core.py
+++ b/yamlator/validators/core.py
@@ -5,7 +5,6 @@ validator handler chian.
 from collections import deque
 from typing import Iterable
 
-from yamlator.types import Data
 from yamlator.types import Rule
 from yamlator.types import YamlatorRuleset
 
@@ -21,21 +20,21 @@ from yamlator.validators import RulesetValidator
 from yamlator.validators.base_validator import Validator
 
 
-def validate_yaml(yaml_data: Data, instructions: dict) -> deque:
+def validate_yaml(yaml_data: dict, instructions: dict) -> deque:
     """Validate YAML data by comparing the data against a set of instructions.
     Any violations will be collected and returned in a `deque`
 
     Args:
-        yaml_data (dict | list | int | float | str): The yaml data to validate
-
-        instructions                         (dict): The instructions containing
-        enums and rulesets that will be validated
+        yaml_data (dict): The YAML data to validate. Assumes the YAML
+            contains a root key
+        instructions (dict): Contains the enums and rulesets that will be
+            used to validate the YAML data
 
     Returns:
-        A deque with the violations that were detected in the data.
+        deque: The violations that were detected in the data.
 
     Raises:
-        ValueError if the parameters `yaml_data` or `instructions` are `None`.
+        ValueError: When the parameters `yaml_data` or `instructions` are `None`
     """
     if yaml_data is None:
         raise ValueError('yaml_data should not be None')

--- a/yamlator/validators/enum_type_validator.py
+++ b/yamlator/validators/enum_type_validator.py
@@ -1,4 +1,4 @@
-"""Validator for handling Enum constructs in the Yamlator schema"""
+"""Validator for handling Enum types"""
 
 from collections import deque
 

--- a/yamlator/validators/enum_type_validator.py
+++ b/yamlator/validators/enum_type_validator.py
@@ -9,32 +9,31 @@ from yamlator.validators.base_validator import Validator
 
 
 class EnumTypeValidator(Validator):
-    """Validator to handle data that is contained in a enum"""
+    """Validator to handle enum types"""
 
     def __init__(self, violations: deque, enums: dict):
         """EnumTypeValidator init
 
         Args:
             violations (deque): Contains violations that have been detected
-            whilst processing the data
-
-            enums       (dict): A dict that contains references to enums
-            referenced in the rulesets.
+                whilst processing the data
+            enums (dict): A dict that contains references to enum values.
         """
         super().__init__(violations)
-        self.enums = enums
+        self._enums = enums
 
     def validate(self, key: str, data: Data, parent: str, rtype: RuleType,
                  is_required: bool = False) -> None:
-        """Validate enum data. If the data does not align to a know value
+        """Validate enum data. If the data does not align to a known value
         in the enum, then a `TypeViolation` is added to the violation list
 
         Args:
-            key              (str): The key to the data
-            data            (Data): The data to validate
-            parent           (str): The parent key of the data
-            rtype       (RuleType): The type assigned to the rule
-            is_required     (bool): Is the rule required
+            key (str): The key to the data
+            data (Data): The data to validate
+            parent (str): The parent key of the data
+            rtype (RuleType): The type assigned to the rule that will be
+                applied to the data
+            is_required (bool, optional): Indicates if the rule is required
         """
         is_enum_type = (rtype.schema_type == SchemaTypes.ENUM)
         if not is_enum_type:
@@ -52,11 +51,11 @@ class EnumTypeValidator(Validator):
         self._add_enum_violation(key, parent, rtype.lookup)
 
     def _matches_enum_data(self, data: Data, enum_name: str) -> bool:
-        target_enum = self.enums.get(enum_name, None)
+        target_enum = self._enums.get(enum_name)
         if target_enum is None:
             return False
 
-        enum_value = target_enum.items.get(data, None)
+        enum_value = target_enum.items.get(data)
         return enum_value is not None
 
     def _add_enum_violation(self, key: str, parent: str, enum_name: str):

--- a/yamlator/validators/list_validator.py
+++ b/yamlator/validators/list_validator.py
@@ -1,24 +1,24 @@
-"""Validator for handling lists in the Yamlator schema"""
+"""Validator for handling lists types"""
 
 
 from yamlator.types import Data
 from yamlator.types import RuleType
 from yamlator.types import SchemaTypes
-from .base_validator import Validator
+from yamlator.validators.base_validator import Validator
 
 
 class ListValidator(Validator):
-    """Validtor for handling list types"""
+    """Validator for handling list types"""
 
-    ruleset_validator: Validator = None
+    _ruleset_validator: Validator = None
 
     def set_ruleset_validator(self, validator: Validator) -> None:
-        """Set a validator for when nested rulesets are within the list
+        """Set a validator for when nested rulesets within the list
 
         Args:
             validator (Validator): The validator to handle rulesets
         """
-        self.ruleset_validator = validator
+        self._ruleset_validator = validator
 
     def validate(self, key: str, data: Data, parent: str, rtype: RuleType,
                  is_required: bool = False) -> None:
@@ -26,11 +26,12 @@ class ListValidator(Validator):
         nested lists are detected in the rule
 
         Args:
-            key              (str): The key to the data
-            data            (Data): The data to validate
-            parent           (str): The parent key of the data
-            rtype       (RuleType): The type assigned to the rule
-            is_required     (bool): Is the rule required
+            key (str): The key to the data
+            data (Data): The data to validate
+            parent (str): The parent key of the data
+            rtype (RuleType): The type assigned to the rule that will be
+                applied to the data
+            is_required (bool, optional): Indicates if the rule is required
         """
         is_list_data = isinstance(data, list)
         is_list_rule = (rtype.schema_type == SchemaTypes.LIST)
@@ -40,8 +41,8 @@ class ListValidator(Validator):
             return
 
         if not is_list_data:
-            self._add_type_violation(key, parent,
-                                     f'{key} should be of type list')
+            message = f'{key} should be of type list'
+            self._add_type_violation(key, parent, message)
             return
 
         for idx, item in enumerate(data):
@@ -66,11 +67,11 @@ class ListValidator(Validator):
 
     def _run_ruleset_validator(self, key: str, parent: str, data: Data,
                                rtype: RuleType) -> None:
-        has_ruleset_validator = (self.ruleset_validator is not None)
+        has_ruleset_validator = (self._ruleset_validator is not None)
         is_ruleset_rule = (rtype.schema_type == SchemaTypes.RULESET)
 
         if has_ruleset_validator and is_ruleset_rule:
-            self.ruleset_validator.validate(
+            self._ruleset_validator.validate(
                 key=key,
                 parent=parent,
                 data=data,

--- a/yamlator/validators/list_validator.py
+++ b/yamlator/validators/list_validator.py
@@ -13,7 +13,7 @@ class ListValidator(Validator):
     _ruleset_validator: Validator = None
 
     def set_ruleset_validator(self, validator: Validator) -> None:
-        """Set a validator for when nested rulesets within the list
+        """Set a validator for handling nested rulesets in the list
 
         Args:
             validator (Validator): The validator to handle rulesets

--- a/yamlator/validators/map_validator.py
+++ b/yamlator/validators/map_validator.py
@@ -1,4 +1,4 @@
-"""Validator for handling maps in the Yamlator schema"""
+"""Validator for handling map types"""
 
 
 from yamlator.types import Data
@@ -15,11 +15,12 @@ class MapValidator(Validator):
         """Validate the data contained within in a map
 
         Args:
-            key              (str): The key to the data
-            data            (Data): The data to validate
-            parent           (str): The parent key of the data
-            rtype       (RuleType): The type assigned to the rule
-            is_required     (bool): Is the rule required
+            key (str): The key to the data
+            data (Data): The data to validate
+            parent (str): The parent key of the data
+            rtype (RuleType): The type assigned to the rule that will be
+                applied to the data
+            is_required (bool, optional): Indicates if the rule is required
         """
         is_map_rule = (rtype.schema_type == SchemaTypes.MAP)
         is_map_data = isinstance(data, dict)
@@ -29,8 +30,8 @@ class MapValidator(Validator):
             return
 
         if not is_map_data:
-            self._add_type_violation(key, parent,
-                                     f'{key} should be of type map')
+            message = f'{key} should be of type map'
+            self._add_type_violation(key, parent, message)
             return
 
         for child_key, value in data.items():

--- a/yamlator/validators/optional_validator.py
+++ b/yamlator/validators/optional_validator.py
@@ -1,4 +1,4 @@
-"""Validator for handling optional rules in the Yamlator schema"""
+"""Validator for handling optional rules"""
 
 
 from yamlator.types import Data
@@ -11,18 +11,19 @@ class OptionalValidator(Validator):
 
     def validate(self, key: str, data: Data, parent: str, rtype: RuleType,
                  is_required: bool = False) -> None:
-        """Validate a key is an optional.
+        """Validate an optional rule.
 
         Args:
-            key              (str): The key to the data
-            data            (Data): The data to validate
-            parent           (str): The parent key of the data
-            rtype       (RuleType): The type assigned to the rule
-            is_required     (bool): Is the rule required
+            key (str): The key to the data
+            data (Data): The data to validate
+            parent (str): The parent key of the data
+            rtype (RuleType): The type assigned to the rule that will be
+                applied to the data
+            is_required (bool, optional): Indicates if the rule is required
         """
 
         missing_data = data is None
-        if not is_required and missing_data:
+        if (not is_required) and missing_data:
             return
 
         super().validate(key, data, parent, rtype, is_required)

--- a/yamlator/validators/regex_validator.py
+++ b/yamlator/validators/regex_validator.py
@@ -1,4 +1,4 @@
-"""Validator for handling regex data types in the Yamlator schema"""
+"""Validator for handling regex data types"""
 
 
 from yamlator.types import Data
@@ -13,17 +13,18 @@ class RegexValidator(Validator):
 
     def validate(self, key: str, data: Data, parent: str, rtype: RuleType,
                  is_required: bool = False) -> None:
-        """Validate a regex rule type against some string data. If the data
-        is a string type, then a `TypeViolation` is added to the violation list.
-        If the string does not match the regex rule, then a `RegexTypeViolation`
-        is added to the violation list.
+        """Validate a regex rule type against a string. If the data
+        is not a string type, then a `TypeViolation` is added to
+        the violation list. If the string does not match the regex
+        rule, then a `RegexTypeViolation` is added to the violation list
 
         Args:
-            key              (str): The key to the data
-            data            (Data): The data to validate
-            parent           (str): The parent key of the data
-            rtype       (RuleType): The type assigned to the rule
-            is_required     (bool): Is the rule required
+            key (str): The key to the data
+            data (Data): The data to validate
+            parent (str): The parent key of the data
+            rtype (RuleType): The type assigned to the rule that will be
+                applied to the data
+            is_required (bool, optional): Indicates if the rule is required
         """
         is_regex_type = (rtype.schema_type == SchemaTypes.REGEX)
         if not is_regex_type:
@@ -31,8 +32,8 @@ class RegexValidator(Validator):
             return
 
         if not isinstance(data, str):
-            self._add_type_violation(key, parent,
-                                     f'{key} should be of type str')
+            message = f'{key} should be of type str'
+            self._add_type_violation(key, parent, message)
             return
 
         if not rtype.regex.search(data):

--- a/yamlator/validators/required_validator.py
+++ b/yamlator/validators/required_validator.py
@@ -1,4 +1,4 @@
-"""Validator for handling required rules in the Yamlator schema"""
+"""Validator for handling required rules"""
 
 
 from yamlator.types import Data
@@ -8,18 +8,19 @@ from .base_validator import Validator
 
 
 class RequiredValidator(Validator):
-    """Validator for handling data that is required"""
+    """Validator for handling required rules"""
 
     def validate(self, key: str, data: Data, parent: str, rtype: RuleType,
                  is_required: bool = False) -> None:
         """Validate a key is a required rule
 
         Args:
-            key              (str): The key to the data
-            data            (Data): The data to validate
-            parent           (str): The parent key of the data
-            rtype       (RuleType): The type assigned to the rule
-            is_required     (bool): Is the rule required
+            key (str): The key to the data
+            data (Data): The data to validate
+            parent (str): The parent key of the data
+            rtype (RuleType): The type assigned to the rule that will be
+                applied to the data
+            is_required (bool, optional): Indicates if the rule is required
         """
 
         missing_data = data is None

--- a/yamlator/validators/ruleset_validator.py
+++ b/yamlator/validators/ruleset_validator.py
@@ -1,4 +1,4 @@
-"""Validator for handling rulesets in the Yamlator schema"""
+"""Validator for handling rulesets types"""
 
 
 from collections import deque
@@ -14,7 +14,7 @@ from .base_validator import Validator
 
 
 class RulesetValidator(Validator):
-    """Validator for handling rulesets"""
+    """Validator for handling rulesets types"""
 
     _ruleset_validator: Validator = None
 
@@ -22,12 +22,11 @@ class RulesetValidator(Validator):
         """RulesetValidator init
 
         Args:
-            violations  (deque):  Contains violations that have been detected
-            whilst processing the data
-
+            violations (deque): contains violations that have been detected
+                whilst processing the data
             instructions (dict): A dict containing references to other rulesets
         """
-        self.instructions = instructions
+        self._instructions = instructions
         super().__init__(violations)
 
     def set_next_ruleset_validator(self, validator: Validator) -> None:
@@ -40,14 +39,28 @@ class RulesetValidator(Validator):
 
     def validate(self, key: str, data: Data, parent: str, rtype: RuleType,
                  is_required: bool = False):
-        """Validate the data against a ruleset
+        """Validate the data against the ruleset type.
+
+        For example, given the following ruleset:
+
+        ```
+        ruleset MyData {
+            message str
+            number int
+        }
+        ```
+
+        Then if the ruleset is assigned as a type to a rule, then this validator
+        will traverse the entire sub structure of the data to validate
+        that all the above data keys and data types are present.
 
         Args:
-            key              (str): The key to the data
-            data            (Data): The data to validate
-            parent           (str): The parent key of the data
-            rtype       (RuleType): The type assigned to the rule
-            is_required     (bool): Is the rule required
+            key (str): The key to the data
+            data (Data): The data to validate
+            parent (str): The parent key of the data
+            rtype (RuleType): The type assigned to the rule that will be
+                applied to the data
+            is_required (bool, optional): Indicates if the rule is required
         """
 
         is_ruleset_rule = (rtype.schema_type == SchemaTypes.RULESET)
@@ -77,5 +90,5 @@ class RulesetValidator(Validator):
 
     def _retrieve_next_ruleset(self, ruleset_name: str) -> Iterable[Rule]:
         default_missing_ruleset = YamlatorRuleset(ruleset_name, [])
-        ruleset = self.instructions.get(ruleset_name, default_missing_ruleset)
+        ruleset = self._instructions.get(ruleset_name, default_missing_ruleset)
         return ruleset.rules


### PR DESCRIPTION
# Changes

* Improved the docstrings in the `validator` sub package
* Improved imports where relative paths were still being used in the `validator` sub package
* Added `__all__` to all `__init__.py` files in the `yamlator` package
* Adjusted messages to be passed in as a variable instead of a string literal
* Adjusted instance variables in certain validators to be protected instead of public