### PR TITLE
Yaml display output

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The first argument for the CLI is always the path to the YAML file.
 | Flag | Alias | Description | Is Required |
 |:-----|:------|:------------|:------------|
 | `--schema` | `-s` | The schema that will be used to validate the YAML file | True |
-| `--output` | `-o` | Defines the violations format that will be displayed. Supported values are `table` or `json`. Defaults to `table` if not specified. | False |
+| `--output` | `-o` | Defines the violations format that will be displayed. Supported values are `table`, `yaml` or `json`. Defaults to `table` if not specified. | False |
 
 To see the help options for the CLI, run `yamlator -h` or `yamlator --help`
 

--- a/tests/cmd/test_yaml_output.py
+++ b/tests/cmd/test_yaml_output.py
@@ -1,0 +1,62 @@
+"""Test cases for the `YAMLOutput` static class
+
+Test Cases:
+    * `test_json_output` tests that the expected status code is returned
+       when valid arguments are provided
+    * `test_json_output_invalid_args` tests that the relevant exception is
+       raised when invalid arguments are provided
+"""
+
+import io
+import unittest
+
+from collections import deque
+from unittest.mock import patch
+from typing import Iterator, Type
+from parameterized import parameterized
+
+from yamlator.cmd import YAMLOutput
+from yamlator.cmd import ERR, SUCCESS
+from yamlator.violations import RequiredViolation
+from yamlator.violations import TypeViolation
+from yamlator.violations import Violation
+
+
+class TestYAMLOutput(unittest.TestCase):
+    """Test the YAMLOutput display method"""
+
+    @parameterized.expand([
+        ('with_no_violations', deque(), SUCCESS),
+        ('with_violations', deque([
+            RequiredViolation(key='message', parent='-'),
+            TypeViolation(key='number', parent='-', message='Invalid number')
+        ]), ERR)
+    ])
+    def test_json_output(self,
+                         name: str,
+                         violations: Iterator[Violation],
+                         expected_status_code: str):
+        # Unused by test case, however is required by the parameterized library
+        del name
+
+        # Suppress the print statements
+        with patch('sys.stdout', new=io.StringIO()):
+            status_code = YAMLOutput.display(violations)
+            self.assertEqual(expected_status_code, status_code)
+
+    @parameterized.expand([
+        ('with_none_violations', None, ValueError)
+    ])
+    def test_yaml_output_invalid_args(self,
+                                      name: str,
+                                      violations: Iterator[Violation],
+                                      expected_exception: Type[Exception]):
+        # Unused by test case, however is required by the parameterized library
+        del name
+
+        with self.assertRaises(expected_exception):
+            YAMLOutput.display(violations)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/cmd/test_yaml_output.py
+++ b/tests/cmd/test_yaml_output.py
@@ -17,6 +17,9 @@ from parameterized import parameterized
 
 from yamlator.cmd import YAMLOutput
 from yamlator.cmd import ERR, SUCCESS
+from yamlator.violations import BuiltInTypeViolation
+from yamlator.violations import RegexTypeViolation
+from yamlator.violations import RulesetTypeViolation
 from yamlator.violations import RequiredViolation
 from yamlator.violations import TypeViolation
 from yamlator.violations import Violation
@@ -29,7 +32,15 @@ class TestYAMLOutput(unittest.TestCase):
         ('with_no_violations', deque(), SUCCESS),
         ('with_violations', deque([
             RequiredViolation(key='message', parent='-'),
-            TypeViolation(key='number', parent='-', message='Invalid number')
+            TypeViolation(key='number', parent='-', message='Invalid number'),
+            BuiltInTypeViolation(key='name',
+                                 parent='-',
+                                 expected_type=str),
+            RulesetTypeViolation(key='address', parent='-'),
+            RegexTypeViolation(key='data',
+                               parent='-',
+                               data='1st January 2022',
+                               regex_str=r'([0-3][0-9]\/){2}2022')
         ]), ERR)
     ])
     def test_json_output(self,

--- a/tests/cmd/test_yaml_output.py
+++ b/tests/cmd/test_yaml_output.py
@@ -1,9 +1,9 @@
 """Test cases for the `YAMLOutput` static class
 
 Test Cases:
-    * `test_json_output` tests that the expected status code is returned
+    * `test_yaml_output` tests that the expected status code is returned
        when valid arguments are provided
-    * `test_json_output_invalid_args` tests that the relevant exception is
+    * `test_yaml_output_invalid_args` tests that the relevant exception is
        raised when invalid arguments are provided
 """
 
@@ -43,7 +43,7 @@ class TestYAMLOutput(unittest.TestCase):
                                regex_str=r'([0-3][0-9]\/){2}2022')
         ]), ERR)
     ])
-    def test_json_output(self,
+    def test_yaml_output(self,
                          name: str,
                          violations: Iterator[Violation],
                          expected_status_code: str):

--- a/yamlator/cmd.py
+++ b/yamlator/cmd.py
@@ -3,10 +3,12 @@
 
 import argparse
 import json
+import yaml
 
 from abc import ABC
 from typing import Iterator
 from enum import Enum
+from collections import deque
 
 from yamlator.utils import load_yaml_file
 from yamlator.utils import load_schema
@@ -17,7 +19,13 @@ from yamlator.validators.core import validate_yaml
 from yamlator.exceptions import InvalidSchemaFilenameError
 from yamlator.exceptions import SchemaParseError
 from yamlator.violations import Violation
+from yamlator.violations import RequiredViolation
+from yamlator.violations import TypeViolation
+from yamlator.violations import BuiltInTypeViolation
+from yamlator.violations import RulesetTypeViolation
+from yamlator.violations import RegexTypeViolation
 from yamlator.violations import ViolationJSONEncoder
+
 
 SUCCESS = 0
 ERR = -1
@@ -72,7 +80,7 @@ def _create_args_parser():
                         validate the YAML file')
 
     parser.add_argument('-o', '--output', type=str, required=False,
-                        default='table', choices=['table', 'json'],
+                        default='table', choices=['table', 'json', 'yaml'],
                         help='Defines the format that will be displayed \
                         for the violations')
     return parser
@@ -107,6 +115,7 @@ class DisplayMethod(Enum):
     """Represents the supported violation display methods"""
     TABLE = 'table'
     JSON = 'json'
+    YAML = 'yaml'
 
 
 def display_violations(violations: Iterator[Violation],
@@ -132,9 +141,14 @@ def display_violations(violations: Iterator[Violation],
     if method is None:
         raise ValueError('method should not be None')
 
-    if method == DisplayMethod.JSON:
-        return JSONOutput.display(violations)
-    return TableOutput.display(violations)
+    strategies = {
+        DisplayMethod.JSON: JSONOutput,
+        DisplayMethod.TABLE: TableOutput,
+        DisplayMethod.YAML: YAMLOutput,
+    }
+
+    display_option = strategies.get(method, TableOutput)
+    return display_option.display(violations)
 
 
 class ViolationOutput(ABC):
@@ -220,3 +234,57 @@ class JSONOutput(ViolationOutput):
         print(json_data)
 
         return SUCCESS if violation_count == 0 else ERR
+
+
+class YAMLOutput(ViolationOutput):
+    """Display violations as YAML"""
+
+    @staticmethod
+    def display(violations: Iterator[Violation]) -> int:
+        """Display the violations to the user as YAML
+
+        Args:
+            violations (Iterator[Violation]): A collection
+            of violations
+
+        Returns:
+            The status code if violations were found. 0 = no
+            violations were found and -1 = violations were found
+        """
+
+        if violations is None:
+            raise ValueError('violations should not be None')
+
+        YAMLOutput._set_up_dumper()
+
+        violation_count = len(violations)
+        data = {
+            'violations': violations,
+            'violationCount': violation_count
+        }
+
+        yaml_str = yaml.dump(data)
+        print(yaml_str)
+        return SUCCESS if violation_count == 0 else ERR
+
+    @staticmethod
+    def _set_up_dumper() -> None:
+        yaml.add_representer(deque, deque_dumper)
+        yaml.add_representer(RequiredViolation, violation_dumper)
+        yaml.add_representer(TypeViolation, violation_dumper)
+        yaml.add_representer(BuiltInTypeViolation, violation_dumper)
+        yaml.add_representer(RulesetTypeViolation, violation_dumper)
+        yaml.add_representer(RegexTypeViolation, violation_dumper)
+
+
+def deque_dumper(dumper: yaml.Dumper, data: deque) -> yaml.SequenceNode:
+    return dumper.represent_list(data)
+
+def violation_dumper(dumper: yaml.Dumper, data: Violation) -> yaml.SequenceNode:
+    data_dict = {
+        'key': data.key,
+        'parent': data.parent,
+        'message': data.message,
+        'violationType': data.violation_type
+    }
+    return dumper.represent_dict(data_dict)

--- a/yamlator/cmd.py
+++ b/yamlator/cmd.py
@@ -280,6 +280,7 @@ class YAMLOutput(ViolationOutput):
 def deque_dumper(dumper: yaml.Dumper, data: deque) -> yaml.SequenceNode:
     return dumper.represent_list(data)
 
+
 def violation_dumper(dumper: yaml.Dumper, data: Violation) -> yaml.SequenceNode:
     data_dict = {
         'key': data.key,


### PR DESCRIPTION
# Changes

* Added a new display option to the CLI to render out the violations as YAML
* Updated `README.md` to include documentation on the new output option
* Refactored the `display_violations` function to use a dictionary instead of if statements
