### PR TITLE
Strict ruleset validation

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,9 +7,9 @@ jobs:
   build-and-publish:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.9
     - name: Install build dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install build dependencies

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,9 +5,9 @@ jobs:
   static-analysis:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.9
     - name: Install dependencies
@@ -32,9 +32,9 @@ jobs:
       max-parallel: 2
       fail-fast: true
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
           python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -48,9 +48,9 @@ jobs:
     needs: validate-python-versions
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.9
     - name: Install dependencies
@@ -62,4 +62,4 @@ jobs:
         coverage run -m unittest
         coverage report -m
     - name: Upload Coverage to Codecov
-      uses: codecov/codecov-action@v2
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install dependencies
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
           python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -50,7 +50,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install dependencies

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,6 @@
 
 * Added `strict` keyword to rulesets to enable strict mode, which will raise a strict violation for every field not defined in the ruleset
 * Added `strict` keyword to schema to enable strict mode, which will raise a strict violation for every field not defined in the schema block
-* Added new example [strict_mode](./example/strict_mode/) to the examples directory
+* Added new example [strict_mode](./example/strict_mode/) to the `example` directory
 * Updated GitHub workloads to use the latest actions
 * Fixed bug with rule definitions where field names with similar character patterns to types would create two separate rules

--- a/changelog.md
+++ b/changelog.md
@@ -23,3 +23,9 @@
 * Added `YAML` as a display option using the CLI
 * Updated docstrings in the `validators` package
 * Updated `cmd.py` to be a sub package in `yamlator` to improve code readability
+
+## v0.2.0 (TBC)
+
+* Added `strict` keyword to rulesets to enable strict mode, which will raise a strict violation for every field not defined in the ruleset
+* Updated GitHub workloads to use the latest actions
+* Fixed bug with rule definitions where field names with similar character patterns to types would create two separate rules

--- a/changelog.md
+++ b/changelog.md
@@ -27,5 +27,6 @@
 ## v0.2.0 (TBC)
 
 * Added `strict` keyword to rulesets to enable strict mode, which will raise a strict violation for every field not defined in the ruleset
+* Added `strict` keyword to schema to enable strict mode, which will raise a strict violation for every field not defined in the schema block
 * Updated GitHub workloads to use the latest actions
 * Fixed bug with rule definitions where field names with similar character patterns to types would create two separate rules

--- a/changelog.md
+++ b/changelog.md
@@ -28,5 +28,6 @@
 
 * Added `strict` keyword to rulesets to enable strict mode, which will raise a strict violation for every field not defined in the ruleset
 * Added `strict` keyword to schema to enable strict mode, which will raise a strict violation for every field not defined in the schema block
+* Added new example [strict_mode](./example/strict_mode/) to the examples directory
 * Updated GitHub workloads to use the latest actions
 * Fixed bug with rule definitions where field names with similar character patterns to types would create two separate rules

--- a/changelog.md
+++ b/changelog.md
@@ -24,7 +24,7 @@
 * Updated docstrings in the `validators` package
 * Updated `cmd.py` to be a sub package in `yamlator` to improve code readability
 
-## v0.2.0 (TBC)
+## v0.2.0 (8th January 2023)
 
 * Added `strict` keyword to rulesets to enable strict mode, which will raise a strict violation for every field not defined in the ruleset
 * Added `strict` keyword to schema to enable strict mode, which will raise a strict violation for every field not defined in the schema block

--- a/docs/schema_components.md
+++ b/docs/schema_components.md
@@ -4,6 +4,9 @@ Below are the various components that can be used to construct a schema with Yam
 
 * [Schema](#schema)
 * [Rulesets](#rulesets)
+* [Strict Mode](#strict-mode)
+  * [Schema](#schema---strict-mode)
+  * [Ruleset](#ruleset---strict-mode)
 * [Rules](#rules)
 * [Enums](#enums)
 * [RuleTypes](#rule-types)
@@ -64,6 +67,58 @@ ruleset Project {
     labels map(str) optional
 }
 ```
+
+## Strict Mode
+
+A schema and ruleset block can be set into strict mode to raise violation errors when fields in the YAML file are not defined in the schema/ruleset block. For every field that is not expected in the block a strict violation is raised.
+
+To use strict mode, the ruleset or schema block should be prefixed with the `strict` keyword.
+
+__NOTE__: Strict mode does not cascade down to other rulesets when defined against a schema or ruleset. Strict mode must be defined on each block that requires it.
+
+### Schema - Strict Mode
+
+For example, given the following schema block:
+
+```text
+strict schema {
+    message str
+    number int optional
+}
+```
+
+Then given the following YAML data:
+
+```yaml
+message: Hello World
+number: 42
+firstName: foo
+lastName: bar
+```
+
+The fields `firstName` and `lastName` will have strict mode violations raised since it does not match the schema block.
+
+### Ruleset - Strict Mode
+
+For example, given the following ruleset:
+
+```text
+strict ruleset Person {
+    firstName str
+    lastName str
+}
+```
+
+Then the following YAML data:
+
+```yaml
+firstName: Foo
+lastName: Bar
+fullName: Foo Bar
+age: 42
+```
+
+The fields `fullName` and `age` will have strict mode violations raised since it does not match the fields specified in the ruleset block.
 
 ## Enums
 

--- a/example/project/project.yaml
+++ b/example/project/project.yaml
@@ -1,5 +1,6 @@
 project:
   version: v1
+  owner: me
   projectId: my-test-project
   displayName: my-test-project
   iam_permission:

--- a/example/project/project.yaml
+++ b/example/project/project.yaml
@@ -1,8 +1,5 @@
 project:
   version: v1
-  owner: me
-  project: foo
-  foo: bar
   projectId: my-test-project
   displayName: my-test-project
   iam_permission:

--- a/example/project/project.yaml
+++ b/example/project/project.yaml
@@ -1,6 +1,8 @@
 project:
   version: v1
   owner: me
+  project: foo
+  foo: bar
   projectId: my-test-project
   displayName: my-test-project
   iam_permission:

--- a/example/project/project.ys
+++ b/example/project/project.ys
@@ -10,7 +10,7 @@ ruleset Details {
     labels map(str)
 }
 
-ruleset Project {
+strict ruleset Project {
     version str
     projectId str
     displayName str

--- a/example/project/project.ys
+++ b/example/project/project.ys
@@ -10,7 +10,7 @@ ruleset Details {
     labels map(str)
 }
 
-strict ruleset Project {
+ruleset Project {
     version str
     projectId str
     displayName str

--- a/example/strict_mode/strict.yaml
+++ b/example/strict_mode/strict.yaml
@@ -1,0 +1,13 @@
+version: v1
+projects:
+  - version: 1
+    name: Project 1
+  - version: 1
+    projectName: Project 2
+  - version: 1
+    name: Project 3
+    description: My awesome third project
+    users:
+      - username: User1
+        role: Developer
+      - username: User2

--- a/example/strict_mode/strict.ys
+++ b/example/strict_mode/strict.ys
@@ -1,0 +1,13 @@
+strict ruleset User {
+    username str required
+}
+
+strict ruleset Project {
+    version int required
+    name str required
+    users list(User) optional
+}
+
+strict schema {
+    projects list(Project)
+}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import setuptools
 
-VERSION = '0.1.2'
+VERSION = '0.2.0'
 PACKAGE_NAME = 'yamlator'
 DESCRIPTION = 'Yamlator is a CLI tool that allows a YAML file to be validated using a lightweight schema language'  # nopep8
 

--- a/tests/cmd/test_yaml_output.py
+++ b/tests/cmd/test_yaml_output.py
@@ -24,6 +24,7 @@ from yamlator.violations import RulesetTypeViolation
 from yamlator.violations import RequiredViolation
 from yamlator.violations import TypeViolation
 from yamlator.violations import Violation
+from yamlator.violations import StrictRulesetViolation
 
 
 class TestYAMLOutput(unittest.TestCase):
@@ -38,6 +39,10 @@ class TestYAMLOutput(unittest.TestCase):
                                  parent='-',
                                  expected_type=str),
             RulesetTypeViolation(key='address', parent='-'),
+            StrictRulesetViolation(key='data',
+                                   parent='-',
+                                   field='message',
+                                   ruleset_name='details'),
             RegexTypeViolation(key='data',
                                parent='-',
                                data='1st January 2022',

--- a/tests/cmd/test_yaml_output.py
+++ b/tests/cmd/test_yaml_output.py
@@ -25,6 +25,7 @@ from yamlator.violations import RequiredViolation
 from yamlator.violations import TypeViolation
 from yamlator.violations import Violation
 from yamlator.violations import StrictRulesetViolation
+from yamlator.violations import StrictEntryPointViolation
 
 
 class TestYAMLOutput(unittest.TestCase):
@@ -43,6 +44,9 @@ class TestYAMLOutput(unittest.TestCase):
                                    parent='-',
                                    field='message',
                                    ruleset_name='details'),
+            StrictEntryPointViolation(key='SCHEMA',
+                                      parent='-',
+                                      field='name'),
             RegexTypeViolation(key='data',
                                parent='-',
                                data='1st January 2022',

--- a/tests/parser/test_parse_schema.py
+++ b/tests/parser/test_parse_schema.py
@@ -20,7 +20,6 @@ from parameterized import parameterized
 from yamlator.utils import load_schema
 from yamlator.parser import parse_schema
 from yamlator.utils import load_yaml_file
-from yamlator.exceptions import SchemaParseError
 from yamlator.parser import MalformedEnumNameError
 from yamlator.parser import MalformedRulesetNameError
 from yamlator.parser import MissingRulesError
@@ -75,7 +74,7 @@ class TestParseSchema(unittest.TestCase):
         (
             'with_ruleset_not_defined',
             './tests/files/invalid_files/missing_defined_ruleset.ys',
-            SchemaParseError
+            SchemaSyntaxError
         ),
         (
             'with_invalid_schema_syntax',

--- a/tests/parser/test_schema_transformer.py
+++ b/tests/parser/test_schema_transformer.py
@@ -98,6 +98,16 @@ class TestSchemaTransformer(unittest.TestCase):
 
         self.assertEqual(name.value, ruleset.name)
         self.assertEqual(len(self.ruleset_rules), len(ruleset.rules))
+        self.assertFalse(ruleset.is_strict)
+
+    def test_strict_ruleset(self):
+        name = Token('person')
+        tokens = (name, *self.ruleset_rules)
+        ruleset = self.transformer.strict_ruleset(tokens)
+
+        self.assertEqual(name.value, ruleset.name)
+        self.assertEqual(len(self.ruleset_rules), len(ruleset.rules))
+        self.assertTrue(ruleset.is_strict)
 
     def test_start(self):
         # This will be zero since main is removed from the dict

--- a/tests/parser/test_schema_transformer.py
+++ b/tests/parser/test_schema_transformer.py
@@ -39,6 +39,9 @@ Test Cases:
     * `test_schema_entry` tests that given a set of rule tokens within
        a schema block, a schema block is generated that contains all
        the specified rules
+    * `test_strict_schema_entry` tests that given a set of rule tokens within
+       a schema block, a schema block is generated that contains all
+       the specified rules in strict mode
     * `test_int_transform` tests transforming a int into an actual
        integer value
     * `test_float_transform` tests transforming a float into an actual
@@ -228,6 +231,16 @@ class TestSchemaTransformer(unittest.TestCase):
 
         self.assertEqual(expected_ruleset_name, ruleset.name)
         self.assertEqual(len(self.ruleset_rules), len(ruleset.rules))
+        self.assertFalse(ruleset.is_strict)
+
+    def test_strict_schema_entry(self):
+        expected_ruleset_name = 'main'
+        tokens = (*self.ruleset_rules, )
+        ruleset = self.transformer.strict_schema_entry(tokens)
+
+        self.assertEqual(expected_ruleset_name, ruleset.name)
+        self.assertEqual(len(self.ruleset_rules), len(ruleset.rules))
+        self.assertTrue(ruleset.is_strict)
 
     def test_int_transform(self):
         expected_value = 42

--- a/tests/validators/test_entry_point_validator.py
+++ b/tests/validators/test_entry_point_validator.py
@@ -1,0 +1,77 @@
+"""Test cases for the `EntryPointValidator`
+
+Test cases:
+    * `test_entry_point_validator` tests the validator when the entry
+       point ruleset is using strict mode to validate if violations
+       are being raised
+"""
+
+
+import unittest
+
+from .base import BaseValidatorTest
+from parameterized import parameterized
+
+from yamlator.types import Rule
+from yamlator.types import RuleType
+from yamlator.types import SchemaTypes
+from yamlator.types import YamlatorRuleset
+from yamlator.validators import EntryPointValidator
+
+
+def _create_ruleset(is_strict=False):
+    rules = [
+        Rule('firstName', RuleType(schema_type=SchemaTypes.STR), True),
+        Rule('lastName', RuleType(schema_type=SchemaTypes.STR), True),
+        Rule('age', RuleType(schema_type=SchemaTypes.INT), False),
+    ]
+    return YamlatorRuleset('main', rules, is_strict=is_strict)
+
+
+class TestEntryPointValidator(BaseValidatorTest):
+    """Test case for the Entry Point Validator"""
+
+    def setUp(self):
+        super().setUp()
+
+        self.parent = '-'
+        self.key = 'SCHEMA'
+        self.rtype = None
+
+    @parameterized.expand([
+        ('not_in_strict_mode_with_extra_fields', {
+            'firstName': 'Test',
+            'lastName': 'Tester',
+            'fullName': 'Test Tester'
+        }, _create_ruleset(), 0),
+        ('not_in_strict_mode_with_expected_fields', {
+            'firstName': 'Test',
+            'lastName': 'Tester',
+            'age': 42
+        }, _create_ruleset(is_strict=False), 0),
+        ('in_strict_mode_without_extra_fields', {
+            'firstName': 'Test',
+            'lastName': 'Tester',
+            'age': 42
+        }, _create_ruleset(is_strict=True), 0),
+        ('in_strict_mode_with_extra_fields', {
+            'firstName': 'Test',
+            'lastName': 'Tester',
+            'fullName': 'Test Tester',
+            'job': 'Tester'
+        }, _create_ruleset(is_strict=True), 2)
+    ])
+    def test_entry_point_validator(self, name: str, data: dict,
+                                   ruleset: YamlatorRuleset,
+                                   expected_violation_count: int):
+        # Unused by test case, however is required by the parameterized library
+        del name
+
+        validator = EntryPointValidator(self.violations, ruleset)
+        validator.validate(self.key, data, self.parent, self.rtype)
+
+        self.assertEqual(expected_violation_count, len(self.violations))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/validators/test_ruleset_validator.py
+++ b/tests/validators/test_ruleset_validator.py
@@ -3,6 +3,8 @@
 Test cases:
     * `test_ruleset_validator` tests the validation of rulesets with
        different possible ways a valid and invalid ruleset can be defined
+    * `test_strict_ruleset_validation` tests the strict ruleset validation
+       with different possible scenarios when using additional fields
 """
 
 
@@ -95,11 +97,17 @@ class TestRuleSetValidator(BaseValidatorTest):
                 'age': 42,
                 'message': 'fake',
                 'name': 'foo bar'
-            }, 2)
+            }, 2),
+        ('with_only_additional_fields',
+            RuleType(schema_type=SchemaTypes.RULESET, lookup='person'),
+            {'message': 'fake', 'name': 'foo bar'}, 2),
+        ('with_empty_data',
+            RuleType(schema_type=SchemaTypes.RULESET, lookup='person'),
+            {}, 0)
     ])
-    def test_strict_ruleset_valiation(self, name: str, rtype: RuleType,
-                                      data: Data,
-                                      expected_violation_count: int):
+    def test_strict_ruleset_validation(self, name: str, rtype: RuleType,
+                                       data: Data,
+                                       expected_violation_count: int):
         # Unused by test case, however is required by the parameterized library
         del name
 

--- a/tests/validators/test_ruleset_validator.py
+++ b/tests/validators/test_ruleset_validator.py
@@ -25,6 +25,7 @@ class TestRuleSetValidator(BaseValidatorTest):
     def setUp(self):
         super().setUp()
         self.instructions = self._create_flat_ruleset()
+        self.strict_instructions = self._create_strict_ruleset()
 
     def _create_flat_ruleset(self):
         message_ruleset = YamlatorRuleset('message', [
@@ -32,9 +33,18 @@ class TestRuleSetValidator(BaseValidatorTest):
             Rule('number', RuleType(schema_type=SchemaTypes.INT), False)
         ])
         return {
-            'rules': {
-                'message': message_ruleset
-            }
+            'message': message_ruleset
+        }
+
+    def _create_strict_ruleset(self):
+        person_ruleset = YamlatorRuleset('person', [
+            Rule('firstName', RuleType(schema_type=SchemaTypes.STR), True),
+            Rule('lastName', RuleType(schema_type=SchemaTypes.STR), True),
+            Rule('age', RuleType(schema_type=SchemaTypes.INT), False),
+        ], is_strict=True)
+
+        return {
+            'person': person_ruleset
         }
 
     @parameterized.expand([
@@ -44,10 +54,10 @@ class TestRuleSetValidator(BaseValidatorTest):
             RuleType(schema_type=SchemaTypes.RULESET), 'hello world', 1),
         ('valid_ruleset',
             RuleType(schema_type=SchemaTypes.RULESET, lookup='message'),
-            {'msg': {'message': 'hello', 'number': 1}}, 0),
+            {'message': 'hello', 'number': 1}, 0),
         ('ruleset_with_no_rules',
             RuleType(schema_type=SchemaTypes.RULESET, lookup='not_real'),
-            {'msg': {'message': 'hello', 'number': 1}}, 0),
+            {'message': 'hello', 'number': 1}, 0),
         ('ruleset_with_none_data',
             RuleType(schema_type=SchemaTypes.RULESET, lookup='not_real'),
             None, 1),
@@ -64,6 +74,36 @@ class TestRuleSetValidator(BaseValidatorTest):
         del name
 
         validator = RulesetValidator(self.violations, self.instructions)
+        validator.validate(
+            key=self.key,
+            data=data,
+            parent=self.parent,
+            rtype=rtype)
+
+        actual_violation_count = len(self.violations)
+        self.assertEqual(expected_violation_count, actual_violation_count)
+
+    @parameterized.expand([
+        ('with_all_fields',
+            RuleType(schema_type=SchemaTypes.RULESET, lookup='person'),
+            {'firstName': 'foo', 'lastName': 'bar', 'age': 42}, 0),
+        ('with_additional_fields',
+            RuleType(schema_type=SchemaTypes.RULESET, lookup='person'),
+            {
+                'firstName': 'foo',
+                'lastName': 'bar',
+                'age': 42,
+                'message': 'fake',
+                'name': 'foo bar'
+            }, 2)
+    ])
+    def test_strict_ruleset_valiation(self, name: str, rtype: RuleType,
+                                      data: Data,
+                                      expected_violation_count: int):
+        # Unused by test case, however is required by the parameterized library
+        del name
+
+        validator = RulesetValidator(self.violations, self.strict_instructions)
         validator.validate(
             key=self.key,
             data=data,

--- a/tests/validators/test_ruleset_validator.py
+++ b/tests/validators/test_ruleset_validator.py
@@ -56,7 +56,7 @@ class TestRuleSetValidator(BaseValidatorTest):
             [0, 1, 2], 1),
         ('ruleset_with_str_data',
             RuleType(schema_type=SchemaTypes.RULESET, lookup='not_real'),
-            'hello world', 1),
+            'hello world', 1)
     ])
     def test_ruleset_validator(self, name: str, rtype: RuleType, data: Data,
                                expected_violation_count: int):

--- a/tests/violations/test_violation_json_encoder.py
+++ b/tests/violations/test_violation_json_encoder.py
@@ -16,11 +16,13 @@ from collections import deque
 from parameterized import parameterized
 from dataclasses import dataclass
 
-from yamlator.violations import BuiltInTypeViolation, RegexTypeViolation
+from yamlator.violations import BuiltInTypeViolation
+from yamlator.violations import RegexTypeViolation
 from yamlator.violations import RequiredViolation
 from yamlator.violations import RulesetTypeViolation
 from yamlator.violations import TypeViolation
 from yamlator.violations import ViolationJSONEncoder
+from yamlator.violations import StrictRulesetViolation
 
 
 @dataclass
@@ -46,7 +48,9 @@ class TestViolationJSONEncoder(unittest.TestCase):
         ('encode_string', 'hello world'),
         ('encode_dict', {'message': 'Hello World', 'number': 43}),
         ('encode_list', [0, 1, 2, 3, 4]),
-        ('encode_none', None)
+        ('encode_none', None),
+        ('encode_strict_ruleset_violation',
+            StrictRulesetViolation('data', '-', 'message', 'details'))
     ])
     def test_violation_json_encoder(self, name: str, data: Any):
         # Unused by test case, however is required by the parameterized library

--- a/tests/violations/test_violation_json_encoder.py
+++ b/tests/violations/test_violation_json_encoder.py
@@ -23,6 +23,7 @@ from yamlator.violations import RulesetTypeViolation
 from yamlator.violations import TypeViolation
 from yamlator.violations import ViolationJSONEncoder
 from yamlator.violations import StrictRulesetViolation
+from yamlator.violations import StrictEntryPointViolation
 
 
 @dataclass
@@ -50,7 +51,9 @@ class TestViolationJSONEncoder(unittest.TestCase):
         ('encode_list', [0, 1, 2, 3, 4]),
         ('encode_none', None),
         ('encode_strict_ruleset_violation',
-            StrictRulesetViolation('data', '-', 'message', 'details'))
+            StrictRulesetViolation('data', '-', 'message', 'details')),
+        ('encode_strict_entry_point_violation',
+            StrictEntryPointViolation('-', 'SCHEMA', 'name'))
     ])
     def test_violation_json_encoder(self, name: str, data: Any):
         # Unused by test case, however is required by the parameterized library

--- a/yamlator/cmd/outputs/yaml_output.py
+++ b/yamlator/cmd/outputs/yaml_output.py
@@ -13,6 +13,7 @@ from yamlator.violations import TypeViolation
 from yamlator.violations import BuiltInTypeViolation
 from yamlator.violations import RulesetTypeViolation
 from yamlator.violations import RegexTypeViolation
+from yamlator.violations import StrictRulesetViolation
 
 
 class YAMLOutput(ViolationOutput):
@@ -57,6 +58,8 @@ class YAMLOutput(ViolationOutput):
         yaml.add_representer(BuiltInTypeViolation, YAMLOutput._violation_dumper)
         yaml.add_representer(RulesetTypeViolation, YAMLOutput._violation_dumper)
         yaml.add_representer(RegexTypeViolation, YAMLOutput._violation_dumper)
+        yaml.add_representer(StrictRulesetViolation,
+                             YAMLOutput._violation_dumper)
 
     @staticmethod
     def _deque_dumper(dumper: yaml.Dumper, data: deque) -> yaml.SequenceNode:

--- a/yamlator/cmd/outputs/yaml_output.py
+++ b/yamlator/cmd/outputs/yaml_output.py
@@ -14,6 +14,7 @@ from yamlator.violations import BuiltInTypeViolation
 from yamlator.violations import RulesetTypeViolation
 from yamlator.violations import RegexTypeViolation
 from yamlator.violations import StrictRulesetViolation
+from yamlator.violations import StrictEntryPointViolation
 
 
 class YAMLOutput(ViolationOutput):
@@ -59,6 +60,8 @@ class YAMLOutput(ViolationOutput):
         yaml.add_representer(RulesetTypeViolation, YAMLOutput._violation_dumper)
         yaml.add_representer(RegexTypeViolation, YAMLOutput._violation_dumper)
         yaml.add_representer(StrictRulesetViolation,
+                             YAMLOutput._violation_dumper)
+        yaml.add_representer(StrictEntryPointViolation,
                              YAMLOutput._violation_dumper)
 
     @staticmethod

--- a/yamlator/grammar/grammar.lark
+++ b/yamlator/grammar/grammar.lark
@@ -6,12 +6,14 @@ start: instructions*
             | ruleset
             | strict_ruleset
             | schema_entry
+            | strict_schema_entry
 
 ?values: INT -> integer
        | FLOAT -> float
        | string
 
 schema_entry: "schema" "{" rule+ "}"
+strict_schema_entry: "strict schema" "{" rule+ "}"
 
 ruleset: "ruleset" /[A-Z]{1}[a-zA-Z0-9_]+/ "{" rule+ "}"
 strict_ruleset: "strict ruleset" /[A-Z]{1}[a-zA-Z0-9_]+/ "{" rule+ "}"

--- a/yamlator/grammar/grammar.lark
+++ b/yamlator/grammar/grammar.lark
@@ -4,6 +4,7 @@ start: instructions*
 // Collection constructs
 ?instructions: enum
             | ruleset
+            | strict_ruleset
             | schema_entry
 
 ?values: INT -> integer
@@ -13,6 +14,7 @@ start: instructions*
 schema_entry: "schema" "{" rule+ "}"
 
 ruleset: "ruleset" /[A-Z]{1}[a-zA-Z0-9_]+/ "{" rule+ "}"
+strict_ruleset: "strict ruleset" /[A-Z]{1}[a-zA-Z0-9_]+/ "{" rule+ "}"
 
 // Enum constructs
 enum: "enum" /[A-Z]{1}[a-zA-Z0-9_]+/ "{" enum_item+ "}"

--- a/yamlator/grammar/grammar.lark
+++ b/yamlator/grammar/grammar.lark
@@ -24,9 +24,9 @@ enum_item: /[A-Z0-9_]+/ "=" values
 ?rule: required_rule
      | optional_rule
 
-required_rule: /[a-zA-Z0-9_]+/ type "required"
-             | /[a-zA-Z0-9_]+/ type
-optional_rule: /[a-zA-Z0-9_]+/ type "optional"
+required_rule: /[a-zA-Z0-9_]+/ type "required" NEW_LINES
+             | /[a-zA-Z0-9_]+/ type NEW_LINES
+optional_rule: /[a-zA-Z0-9_]+/ type "optional" NEW_LINES
 
 // Data types for rules
 type: int_type

--- a/yamlator/parser.py
+++ b/yamlator/parser.py
@@ -82,12 +82,12 @@ class SchemaTransformer(Transformer):
 
     def required_rule(self, tokens: Any) -> Rule:
         """Transforms the required rule tokens in a Rule object"""
-        (name, rtype) = tokens
+        (name, rtype) = tokens[0:2]
         return Rule(name.value, rtype, True)
 
     def optional_rule(self, tokens: Any) -> Rule:
         """Transforms the optional rule tokens in a Rule object"""
-        (name, rtype) = tokens
+        (name, rtype) = tokens[0:2]
         return Rule(name.value, rtype, False)
 
     def ruleset(self, tokens: Any) -> YamlatorRuleset:

--- a/yamlator/parser.py
+++ b/yamlator/parser.py
@@ -97,6 +97,12 @@ class SchemaTransformer(Transformer):
         self.seen_constructs[name] = SchemaTypes.RULESET
         return YamlatorRuleset(name, rules)
 
+    def strict_ruleset(self, tokens: Any) -> YamlatorRuleset:
+        name = tokens[0].value
+        rules = tokens[1:]
+        self.seen_constructs[name] = SchemaTypes.RULESET
+        return YamlatorRuleset(name, rules, is_strict=True)
+
     def start(self, instructions: Iterator[YamlatorType]) -> dict:
         """Transforms the instructions into a dict that sorts the rulesets,
         enums and entry point to validate YAML data"""

--- a/yamlator/parser.py
+++ b/yamlator/parser.py
@@ -98,6 +98,9 @@ class SchemaTransformer(Transformer):
         return YamlatorRuleset(name, rules)
 
     def strict_ruleset(self, tokens: Any) -> YamlatorRuleset:
+        """Transforms the ruleset tokens into a YamlatorRuleset object
+        and marks the ruleset as being in strict mode
+        """
         name = tokens[0].value
         rules = tokens[1:]
         self.seen_constructs[name] = SchemaTypes.RULESET

--- a/yamlator/parser.py
+++ b/yamlator/parser.py
@@ -205,6 +205,9 @@ class SchemaTransformer(Transformer):
         """
         return YamlatorRuleset('main', rules)
 
+    def strict_schema_entry(self, rules: list) -> YamlatorRuleset:
+        return YamlatorRuleset('main', rules, is_strict=True)
+
     @v_args(inline=True)
     def integer(self, token: str) -> int:
         """Convers a integer string into a int type"""

--- a/yamlator/types.py
+++ b/yamlator/types.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 
 from enum import Enum, auto
-from typing import Union
+from typing import Union, Iterator
 from collections import namedtuple
 
 Rule = namedtuple('Rule', ['name', 'rtype', 'is_required'])
@@ -107,8 +107,12 @@ class YamlatorRuleset(YamlatorType):
             rules   (list): A list of rules for the ruleset
         """
         super().__init__(name, ContainerTypes.RULESET)
-        self.rules = rules
+        self._rules = rules
         self.is_strict = is_strict
+
+    @property
+    def rules(self) -> Iterator[Rule]:
+        return self._rules
 
 
 class YamlatorEnum(YamlatorType):

--- a/yamlator/types.py
+++ b/yamlator/types.py
@@ -111,15 +111,11 @@ class YamlatorRuleset(YamlatorType):
         """
         super().__init__(name, ContainerTypes.RULESET)
         self._rules = rules
-        self._is_strict = is_strict
+        self.is_strict = is_strict
 
     @property
     def rules(self) -> Iterator[Rule]:
         return self._rules
-
-    @property
-    def is_strict(self) -> bool:
-        return self._is_strict
 
 
 class YamlatorEnum(YamlatorType):

--- a/yamlator/types.py
+++ b/yamlator/types.py
@@ -99,7 +99,7 @@ class YamlatorRuleset(YamlatorType):
     rules of `RuleType` which will validated against
     """
 
-    def __init__(self, name: str, rules: list):
+    def __init__(self, name: str, rules: list, is_strict: bool = False):
         """YamlatorRuleset init
 
         Args:
@@ -108,6 +108,7 @@ class YamlatorRuleset(YamlatorType):
         """
         super().__init__(name, ContainerTypes.RULESET)
         self.rules = rules
+        self.is_strict = is_strict
 
 
 class YamlatorEnum(YamlatorType):

--- a/yamlator/types.py
+++ b/yamlator/types.py
@@ -103,16 +103,23 @@ class YamlatorRuleset(YamlatorType):
         """YamlatorRuleset init
 
         Args:
-            name     (str): The name of the ruleset
-            rules   (list): A list of rules for the ruleset
+            name       (str): The name of the ruleset
+            rules     (list): A list of rules for the ruleset
+            is_strict (bool): Sets the ruleset to be in strict mode.
+            When used with the validators, it will check to ensure any
+            extra fields are raised as a violation
         """
         super().__init__(name, ContainerTypes.RULESET)
         self._rules = rules
-        self.is_strict = is_strict
+        self._is_strict = is_strict
 
     @property
     def rules(self) -> Iterator[Rule]:
         return self._rules
+
+    @property
+    def is_strict(self) -> bool:
+        return self._is_strict
 
 
 class YamlatorEnum(YamlatorType):

--- a/yamlator/types.py
+++ b/yamlator/types.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 import re
 
-from enum import Enum, auto
-from typing import Union, Iterator
+from enum import Enum
+from enum import auto
+from typing import Union
+from typing import Iterator
 from collections import namedtuple
 
 Rule = namedtuple('Rule', ['name', 'rtype', 'is_required'])

--- a/yamlator/validators/__init__.py
+++ b/yamlator/validators/__init__.py
@@ -9,6 +9,7 @@ from yamlator.validators.optional_validator import OptionalValidator
 from yamlator.validators.regex_validator import RegexValidator
 from yamlator.validators.required_validator import RequiredValidator
 from yamlator.validators.ruleset_validator import RulesetValidator
+from yamlator.validators.entry_point_validator import EntryPointValidator
 
 
 __all__ = [
@@ -20,5 +21,6 @@ __all__ = [
     'OptionalValidator',
     'RegexValidator',
     'RequiredValidator',
-    'RulesetValidator'
+    'RulesetValidator',
+    'EntryPointValidator'
 ]

--- a/yamlator/validators/core.py
+++ b/yamlator/validators/core.py
@@ -3,9 +3,6 @@ validator handler chian.
 """
 
 from collections import deque
-from typing import Iterable
-
-from yamlator.types import Rule
 from yamlator.types import YamlatorRuleset
 
 from yamlator.validators import AnyTypeValidator
@@ -17,8 +14,8 @@ from yamlator.validators import OptionalValidator
 from yamlator.validators import RegexValidator
 from yamlator.validators import RequiredValidator
 from yamlator.validators import RulesetValidator
+from yamlator.validators import EntryPointValidator
 from yamlator.validators.base_validator import Validator
-from yamlator.violations import StrictRulesetViolation
 
 
 def validate_yaml(yaml_data: dict, instructions: dict) -> deque:
@@ -43,41 +40,23 @@ def validate_yaml(yaml_data: dict, instructions: dict) -> deque:
     if instructions is None:
         raise ValueError('instructions should not be None')
 
-    entry_parent = '-'
+    default_key = '-'
     violations = deque()
-    entry_point: YamlatorRuleset = instructions.get('main',
-                                                    YamlatorRuleset('main', []))
 
-    validators = _create_validators_chain(
-        ruleset_lookups=instructions.get('rules', {}),
-        enum_looksups=instructions.get('enums', {}),
-        violations=violations
-    )
-
-    entry_point_rules: Iterable[Rule] = entry_point.rules
-
-    if entry_point.is_strict:
-        _validate_entry_point_strict_mode(yaml_data, entry_point_rules, violations)
-
-    for rule in entry_point_rules:
-        sub_data = yaml_data.get(rule.name, None)
-
-        validators.validate(
-            key=rule.name,
-            data=sub_data,
-            parent=entry_parent,
-            rtype=rule.rtype,
-            is_required=rule.is_required
-        )
+    validators = _create_validators_chain(instructions, violations)
+    validators.validate(default_key, yaml_data, default_key, None)
 
     return violations
 
 
-def _create_validators_chain(ruleset_lookups: dict,
-                             enum_looksups: dict,
+def _create_validators_chain(instructions: dict,
                              violations: deque) -> Validator:
+    ruleset_lookups = instructions.get('rules', {})
+    enum_looksups = instructions.get('enums', {})
+    entry_point = instructions.get('main', YamlatorRuleset('main', []))
 
-    root = OptionalValidator(violations)
+    root = EntryPointValidator(violations, entry_point)
+    optional_validator = OptionalValidator(violations)
     any_type_validator = AnyTypeValidator(violations)
     required_validator = RequiredValidator(violations)
     map_validator = MapValidator(violations)
@@ -87,11 +66,12 @@ def _create_validators_chain(ruleset_lookups: dict,
     type_validator = BuiltInTypeValidator(violations)
     regex_validator = RegexValidator(violations)
 
-    root.set_next_validator(required_validator)
+    root.set_next_validator(optional_validator)
+    optional_validator.set_next_validator(required_validator)
     required_validator.set_next_validator(map_validator)
     map_validator.set_next_validator(ruleset_validator)
 
-    ruleset_validator.set_next_ruleset_validator(root)
+    ruleset_validator.set_next_ruleset_validator(optional_validator)
     ruleset_validator.set_next_validator(list_validator)
 
     list_validator.set_ruleset_validator(ruleset_validator)
@@ -101,13 +81,3 @@ def _create_validators_chain(ruleset_lookups: dict,
     any_type_validator.set_next_validator(regex_validator)
     regex_validator.set_next_validator(type_validator)
     return root
-
-
-def _validate_entry_point_strict_mode(data: dict, rules: Iterable[Rule], violations: deque) -> None:
-    rule_fields = {rule.name for rule in rules}
-    data_fields = set(data.keys())
-    extra_fields = data_fields - rule_fields
-
-    for field in extra_fields:
-        violation = StrictRulesetViolation(key='-', parent='-', field=field, ruleset_name='entry')
-        violations.append(violation)

--- a/yamlator/validators/entry_point_validator.py
+++ b/yamlator/validators/entry_point_validator.py
@@ -1,0 +1,44 @@
+from collections import deque
+from typing import Iterable
+
+from yamlator.types import Data
+from yamlator.types import Rule
+from yamlator.types import RuleType
+from yamlator.types import YamlatorRuleset
+from yamlator.violations import StrictEntryPointViolation
+from .base_validator import Validator
+
+
+class EntryPointValidator(Validator):
+
+    def __init__(self, violations: deque, entry_point: YamlatorRuleset):
+        self._entry_point = entry_point
+        super().__init__(violations)
+
+    def validate(self, key: str, data: Data, parent: str, rtype: RuleType,
+                 is_required: bool = False) -> None:
+        del key
+        del rtype
+        del is_required
+
+        rules = self._entry_point.rules
+        if self._entry_point.is_strict:
+            self._handle_strict_mode(data, rules)
+
+        for rule in rules:
+            sub_data = data.get(rule.name, None)
+
+            super().validate(rule.name, sub_data, parent,
+                             rule.rtype, rule.is_required)
+
+    def _handle_strict_mode(self, data: dict, rules: Iterable[Rule]):
+        rule_fields = {rule.name for rule in rules}
+        data_fields = set(data.keys())
+        extra_fields = data_fields - rule_fields
+
+        for field in extra_fields:
+            violation = StrictEntryPointViolation(
+                    key='-',
+                    parent='-',
+                    field=field)
+            self._violations.append(violation)

--- a/yamlator/validators/entry_point_validator.py
+++ b/yamlator/validators/entry_point_validator.py
@@ -1,3 +1,6 @@
+"""Validator for handling the entry point ruleset"""
+
+
 from collections import deque
 from typing import Iterable
 
@@ -10,13 +13,32 @@ from .base_validator import Validator
 
 
 class EntryPointValidator(Validator):
+    """Validator to handle the `schema` / entry point of the Yamlator rules"""
 
     def __init__(self, violations: deque, entry_point: YamlatorRuleset):
+        """EntryPointValidator init
+
+        Args:
+            violations (deque): contains violations that have been
+                detected whilst processing the data
+            entry_point (YamlatorRuleset): The entry point ruleset
+        """
         self._entry_point = entry_point
         super().__init__(violations)
 
     def validate(self, key: str, data: Data, parent: str, rtype: RuleType,
                  is_required: bool = False) -> None:
+        """Validate the entry point ruleset and validate each
+        rule by calling the next validator in the chain
+
+        Args:
+            key (str): The key to the data
+            data (Data): The data to validate
+            parent (str): The parent key of the data
+            rtype (RuleType): The type assigned to the rule that will be
+                applied to the data
+            is_required (bool, optional): Indicates if the rule is required
+        """
         del key
         del rtype
         del is_required
@@ -38,7 +60,7 @@ class EntryPointValidator(Validator):
 
         for field in extra_fields:
             violation = StrictEntryPointViolation(
-                    key='-',
+                    key='SCHEMA',
                     parent='-',
                     field=field)
             self._violations.append(violation)

--- a/yamlator/validators/ruleset_validator.py
+++ b/yamlator/validators/ruleset_validator.py
@@ -73,7 +73,7 @@ class RulesetValidator(Validator):
             self._violations.append(violation)
             return
 
-        ruleset = self._retrieve_next_ruleset(rtype.lookup)
+        ruleset = self._retrieve_ruleset(rtype.lookup)
 
         self._handle_strict_violations(key, parent, ruleset, data)
 
@@ -89,7 +89,7 @@ class RulesetValidator(Validator):
                     is_required=ruleset_rule.is_required
                 )
 
-    def _retrieve_next_ruleset(self, ruleset_name: str) -> YamlatorRuleset:
+    def _retrieve_ruleset(self, ruleset_name: str) -> YamlatorRuleset:
         default_missing_ruleset = YamlatorRuleset(ruleset_name, [])
         ruleset = self._instructions.get(ruleset_name, default_missing_ruleset)
         return ruleset
@@ -99,8 +99,12 @@ class RulesetValidator(Validator):
         if not ruleset.is_strict:
             return
 
-        rule_fields = set([rule.name for rule in ruleset.rules])
+        rule_fields = {rule.name for rule in ruleset.rules}
         data_fields = set(data.keys())
+
+        # Find the differance between the data and
+        # the ruleset fields to determine the additional
+        # fields that have been added to the YAML file
         extra_fields = data_fields - rule_fields
 
         for field in extra_fields:

--- a/yamlator/validators/ruleset_validator.py
+++ b/yamlator/validators/ruleset_validator.py
@@ -74,7 +74,6 @@ class RulesetValidator(Validator):
             return
 
         ruleset = self._retrieve_ruleset(rtype.lookup)
-
         self._handle_strict_violations(key, parent, ruleset, data)
 
         for ruleset_rule in ruleset.rules:

--- a/yamlator/validators/ruleset_validator.py
+++ b/yamlator/validators/ruleset_validator.py
@@ -101,7 +101,7 @@ class RulesetValidator(Validator):
         rule_fields = {rule.name for rule in ruleset.rules}
         data_fields = set(data.keys())
 
-        # Find the differance between the data and
+        # Find the difference between the data and
         # the ruleset fields to determine the additional
         # fields that have been added to the YAML file
         extra_fields = data_fields - rule_fields

--- a/yamlator/violations.py
+++ b/yamlator/violations.py
@@ -12,6 +12,7 @@ from typing import Any
 class ViolationType(Enum):
     REQUIRED = 'required'
     TYPE = 'type'
+    STRICT = 'strict'
 
 
 class ViolationJSONEncoder(json.JSONEncoder):
@@ -141,8 +142,7 @@ class RegexTypeViolation(TypeViolation):
         super().__init__(key, parent, message)
 
 
-class StrictRulesetViolation(TypeViolation):
-    def __init__(self, key: str, parent: str, additional_fields: list[str]):
-        fields = ",".join(additional_fields)
-        message = f"strict ruleset violation. Additional fields found: {fields}"
-        super().__init__(key, parent, message)
+class StrictRulesetViolation(Violation):
+    def __init__(self, key: str, parent: str, field: str, ruleset_name: str):
+        message = f"{field} is not expected in ruleset {ruleset_name}"
+        super().__init__(key, parent, message, ViolationType.STRICT)

--- a/yamlator/violations.py
+++ b/yamlator/violations.py
@@ -143,18 +143,42 @@ class RegexTypeViolation(TypeViolation):
 
 
 class StrictViolation(Violation):
+    """Violation for when a type violates strict mode"""
+
     def __init__(self, key: str, parent: str, message: str):
+        """StrictViolation init
+
+        Args:
+            key          (str):  The key name in the YAML file
+            parent       (str):  The parent key in the YAML file
+            message      (str):  The message with information
+                regarding the type violation
+        """
         super().__init__(key, parent, message, ViolationType.STRICT)
 
 
 class StrictEntryPointViolation(StrictViolation):
+    """Violation for when the entry point (schema) is in strict mode
+    and has additional fields
+    """
+
     def __init__(self, key: str, parent: str, field: str):
+        """StrictEntryPointViolation init
+
+        Args:
+            key          (str):  The key name in the YAML file
+            parent       (str):  The parent key in the YAML file
+            field        (str):  The name of the additional field
+                in the entry point
+        """
         message = f'{field} is not expected in entry point schema'
         super().__init__(key, parent, message)
 
 
 class StrictRulesetViolation(StrictViolation):
-    """Violation for when ruleset in strict mode has additional fields"""
+    """Violation for when a ruleset is in strict mode and has
+    additional fields
+    """
 
     def __init__(self, key: str, parent: str, field: str, ruleset_name: str):
         """StrictRulesetViolation init

--- a/yamlator/violations.py
+++ b/yamlator/violations.py
@@ -143,6 +143,16 @@ class RegexTypeViolation(TypeViolation):
 
 
 class StrictRulesetViolation(Violation):
+    """Violation for when ruleset in strict mode has additional fields"""
+
     def __init__(self, key: str, parent: str, field: str, ruleset_name: str):
+        """StrictRulesetViolation init
+
+        Args:
+            key          (str):  The key name in the YAML file
+            parent       (str):  The parent key in the YAML file
+            field        (str):  The name of the additional field in the ruleset
+            ruleset_name (str):  The name of the ruleset
+        """
         message = f"{field} is not expected in ruleset {ruleset_name}"
         super().__init__(key, parent, message, ViolationType.STRICT)

--- a/yamlator/violations.py
+++ b/yamlator/violations.py
@@ -154,5 +154,5 @@ class StrictRulesetViolation(Violation):
             field        (str):  The name of the additional field in the ruleset
             ruleset_name (str):  The name of the ruleset
         """
-        message = f"{field} is not expected in ruleset {ruleset_name}"
+        message = f'{field} is not expected in ruleset {ruleset_name}'
         super().__init__(key, parent, message, ViolationType.STRICT)

--- a/yamlator/violations.py
+++ b/yamlator/violations.py
@@ -139,3 +139,10 @@ class RegexTypeViolation(TypeViolation):
         """
         message = f'{data} does not match regex "{regex_str}"'
         super().__init__(key, parent, message)
+
+
+class StrictRulesetViolation(TypeViolation):
+    def __init__(self, key: str, parent: str, additional_fields: list[str]):
+        fields = ",".join(additional_fields)
+        message = f"strict ruleset violation. Additional fields found: {fields}"
+        super().__init__(key, parent, message)

--- a/yamlator/violations.py
+++ b/yamlator/violations.py
@@ -142,7 +142,18 @@ class RegexTypeViolation(TypeViolation):
         super().__init__(key, parent, message)
 
 
-class StrictRulesetViolation(Violation):
+class StrictViolation(Violation):
+    def __init__(self, key: str, parent: str, message: str):
+        super().__init__(key, parent, message, ViolationType.STRICT)
+
+
+class StrictEntryPointViolation(StrictViolation):
+    def __init__(self, key: str, parent: str, field: str):
+        message = f'{field} is not expected in entry point schema'
+        super().__init__(key, parent, message)
+
+
+class StrictRulesetViolation(StrictViolation):
     """Violation for when ruleset in strict mode has additional fields"""
 
     def __init__(self, key: str, parent: str, field: str, ruleset_name: str):
@@ -155,4 +166,4 @@ class StrictRulesetViolation(Violation):
             ruleset_name (str):  The name of the ruleset
         """
         message = f'{field} is not expected in ruleset {ruleset_name}'
-        super().__init__(key, parent, message, ViolationType.STRICT)
+        super().__init__(key, parent, message)

--- a/yamlator/violations.py
+++ b/yamlator/violations.py
@@ -171,7 +171,7 @@ class StrictEntryPointViolation(StrictViolation):
             field        (str):  The name of the additional field
                 in the entry point
         """
-        message = f'{field} is not expected in entry point schema'
+        message = f'{field} is not expected in the schema block'
         super().__init__(key, parent, message)
 
 


### PR DESCRIPTION
# Changes

* Added `strict` keyword to rulesets to enable strict mode, which will raise a strict violation for every field not defined in the ruleset
* Added `strict` keyword to schema to enable strict mode, which will raise a strict violation for every field not defined in the schema block
* Added new example [strict_mode](./example/strict_mode/) to the examples directory
* Updated GitHub workloads to use the latest actions
* Fixed bug with rule definitions where field names with similar character patterns to types would create two separate rules